### PR TITLE
Fix missing left bracket in Project JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ In the right panel, select *JSON editor* and paste the following:
 ```
 
 *** Project *** (Repeatable)
-```{
+```
+{
   "Main" : {
     "project_title" : {
       "type" : "StructuredText",


### PR DESCRIPTION
The ``` were on the same line as the opening bracket for the Project JSON causing it to not be visible.